### PR TITLE
Fix FileNotFoundError in XML Constellations Testing by Ensuring Required Directories Exist

### DIFF
--- a/src/constellation_generation/by_XML/constellation_configuration.py
+++ b/src/constellation_generation/by_XML/constellation_configuration.py
@@ -51,6 +51,10 @@ def constellation_configuration(dT , constellation_name):
     # convert string to int type
     number_of_shells = int(constellation_configuration_information['constellation']['number_of_shells'])
     shells = []
+    # ensure the data/XML_constellation/ directory exists
+    data_directory = "data/XML_constellation/"
+    # This will create the directory if it does not exist
+    os.makedirs(data_directory, exist_ok=True)
     # determine whether the .h5 file of the delay and satellite position data of the current constellation exists. If
     # it exists, delete the file and create an empty .h5 file. If it does not exist, directly create an empty .h5 file.
     file_path = "data/XML_constellation/" + constellation_name + ".h5"


### PR DESCRIPTION
## Description

During the execution of the XML Constellations Testing as part of the StarPerf suite, a `FileNotFoundError` is encountered when the system attempts to create a `.h5` file in the `data/XML_constellation/` directory. This error is traced back to the non-existence of the `data/XML_constellation/` directory, a situation commonly arising after a fresh `git clone` of the repository. Since Git does not track empty directories, the required `data/XML_constellation/` directory is absent, leading to runtime errors when the system attempts file operations within this directory.

The primary cause of this issue is the nature of `git clone` operations where directories without files are not created in the cloned repository. As a result, the expected directory structure needed for file operations does not exist, causing runtime errors during constellation data generation.

## Log

```
Starting StarPerf...
    Starting XML Constellations Testing...
        Test(01/16) : constellation generation
Traceback (most recent call last):
...
FileNotFoundError: [Errno 2] Unable to synchronously create file (unable to open file: name = 'data/XML_constellation/Starlink.h5', errno = 2, error message = 'No such file or directory', flags = 13, o_flags = 302)
```

## Solution

Modified the `constellation_configuration` function to check and create the `data/XML_constellation/` directory if it does not exist. This is achieved using the `os.makedirs()` function with the `exist_ok=True` parameter, ensuring idempotency.

## Testing

 :white_check_mark: Ensured existing unit tests pass with the proposed changes
 :white_check_mark: Manual testing performed post-`git clone` to validate the fix